### PR TITLE
fix: remove duplicate license field in dist package.json

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -55,8 +55,7 @@ cat >dist/package.json <<EOF
     }
   },
   "browser": "./browser/index.js",
-  "sideEffects": false,
-  "license": "MIT"
+  "sideEffects": false
 }
 EOF
 


### PR DESCRIPTION
Thanks for the amazing library!

I found a minor bug causing the license field to be duplicated in the dist `package.json`, which causes a warning when consuming the library within a Bun app:

```bash
$ bun --hot run src/index.ts
42 |   "license": "MIT"
       ^
warn: Duplicate key "license" in object literal
   at <repo>/node_modules/.bun/openelectricity@0.7.1-0/node_modules/openelectricity/dist/package.json:42:3
```