### PR TITLE
test: gap fills + datatable empty-data fix

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -57,7 +57,7 @@ export class DataTable {
    */
   public static fromNetworkTimeSeries(data: INetworkTimeSeries[]): DataTable {
     const rows: IDataTableRow[] = []
-    const groupings = data[0].groupings || []
+    const groupings = data[0]?.groupings ?? []
     const metrics = new Map<string, string>()
     const table = new DataTable(rows, groupings, metrics)
 

--- a/tests/client.metrics.test.ts
+++ b/tests/client.metrics.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  NoDataFound,
+  OpenElectricityClient,
+  OpenElectricityError,
+} from "../src"
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch as unknown as typeof fetch
+
+describe("getAvailableMetrics", () => {
+  let client: OpenElectricityClient
+
+  beforeEach(() => {
+    client = new OpenElectricityClient({ apiKey: "test-key" })
+    vi.clearAllMocks()
+  })
+
+  it("returns metrics on 200", async () => {
+    const body = {
+      metrics: {
+        power: {
+          name: "power",
+          unit: "MW",
+          description: "Power output",
+          default_aggregation: "mean",
+          precision: 2,
+        },
+      },
+      total: 1,
+      endpoints: { market: [], data: ["power"] },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    } as Response)
+
+    const result = await client.getAvailableMetrics()
+    expect(result.total).toBe(1)
+    expect(result.metrics.power.unit).toBe("MW")
+  })
+
+  it("throws NoDataFound on 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(client.getAvailableMetrics()).rejects.toBeInstanceOf(
+      NoDataFound,
+    )
+  })
+
+  it("throws permission error on 403", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(client.getAvailableMetrics()).rejects.toThrow(
+      /Permission denied/,
+    )
+  })
+
+  it("throws OpenElectricityError on 500 with non-JSON body", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("not json")),
+    } as Response)
+
+    await expect(client.getAvailableMetrics()).rejects.toBeInstanceOf(
+      OpenElectricityError,
+    )
+  })
+})

--- a/tests/client.pollution.test.ts
+++ b/tests/client.pollution.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { NoDataFound, OpenElectricityClient } from "../src"
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch as unknown as typeof fetch
+
+describe("getFacilityPollution", () => {
+  let client: OpenElectricityClient
+
+  beforeEach(() => {
+    client = new OpenElectricityClient({ apiKey: "test-key" })
+    vi.clearAllMocks()
+  })
+
+  it("returns datatable for populated response", async () => {
+    const body = {
+      version: "4.0.1",
+      created_at: "2024-01-01T00:00:00",
+      success: true,
+      error: null,
+      data: [
+        {
+          network_code: "NEM",
+          metric: "pollution",
+          unit: "kg",
+          interval: "1y",
+          start: "2023-01-01T00:00:00",
+          end: "2024-01-01T00:00:00",
+          groupings: [],
+          results: [
+            {
+              name: "ERARING_nox",
+              date_start: "2023-01-01T00:00:00",
+              date_end: "2024-01-01T00:00:00",
+              columns: { facility_code: "ERARING", pollutant_code: "nox" },
+              data: [["2023-01-01T00:00:00", 12345]],
+            },
+          ],
+          network_timezone_offset: "+10:00",
+        },
+      ],
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    } as Response)
+
+    const result = await client.getFacilityPollution({
+      facility_code: ["ERARING"],
+      pollutant_code: ["nox"],
+    })
+
+    expect(result.response.success).toBe(true)
+    expect(result.datatable).toBeDefined()
+  })
+
+  it("omits datatable when response.data is empty", async () => {
+    const body = {
+      version: "4.0.1",
+      created_at: "2024-01-01T00:00:00",
+      success: true,
+      error: null,
+      data: [],
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    } as Response)
+
+    const result = await client.getFacilityPollution()
+    expect(result.response.data).toEqual([])
+    expect(result.datatable).toBeUndefined()
+  })
+
+  it("throws NoDataFound on 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(
+      client.getFacilityPollution({ facility_code: ["DOES_NOT_EXIST"] }),
+    ).rejects.toBeInstanceOf(NoDataFound)
+  })
+})

--- a/tests/client.tz_warning.test.ts
+++ b/tests/client.tz_warning.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { OpenElectricityClient } from "../src"
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch as unknown as typeof fetch
+
+function emptyTimeseries() {
+  return {
+    version: "4.0.1",
+    created_at: "2024-01-01T00:00:00",
+    success: true,
+    error: null,
+    data: [],
+  }
+}
+
+describe("tz-aware date stripping", () => {
+  let client: OpenElectricityClient
+
+  beforeEach(() => {
+    client = new OpenElectricityClient({ apiKey: "test-key" })
+    vi.clearAllMocks()
+  })
+
+  it("strips trailing Z from dateStart and dateEnd", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(emptyTimeseries()),
+    } as Response)
+
+    await client.getNetworkData("NEM", ["energy"], {
+      dateStart: "2024-01-01T00:00:00Z",
+      dateEnd: "2024-01-02T00:00:00Z",
+    })
+
+    const url = String(mockFetch.mock.calls[0][0])
+    expect(url).toContain("date_start=2024-01-01T00%3A00%3A00")
+    expect(url).toContain("date_end=2024-01-02T00%3A00%3A00")
+    expect(url).not.toContain("Z&")
+    expect(url).not.toMatch(/Z$/)
+  })
+
+  it("strips +HH:MM offsets", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(emptyTimeseries()),
+    } as Response)
+
+    await client.getNetworkData("NEM", ["energy"], {
+      dateStart: "2024-01-01T00:00:00+10:00",
+    })
+
+    const url = String(mockFetch.mock.calls[0][0])
+    expect(url).toContain("date_start=2024-01-01T00%3A00%3A00")
+    expect(url).not.toContain("%2B10")
+  })
+
+  it("passes naive dates through unchanged", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(emptyTimeseries()),
+    } as Response)
+
+    await client.getNetworkData("NEM", ["energy"], {
+      dateStart: "2024-01-01T00:00:00",
+    })
+
+    const url = String(mockFetch.mock.calls[0][0])
+    expect(url).toContain("date_start=2024-01-01T00%3A00%3A00")
+  })
+})

--- a/tests/client.user.test.ts
+++ b/tests/client.user.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { OpenElectricityClient } from "../src"
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch as unknown as typeof fetch
+
+describe("getCurrentUser", () => {
+  let client: OpenElectricityClient
+
+  beforeEach(() => {
+    client = new OpenElectricityClient({ apiKey: "test-key" })
+    vi.clearAllMocks()
+  })
+
+  it("returns user with full envelope", async () => {
+    const body = {
+      version: "4.0.1",
+      created_at: "2024-01-01T00:00:00",
+      success: true,
+      error: null,
+      data: {
+        id: "u_1",
+        full_name: "Test User",
+        email: "test@example.com",
+        owner_id: "o_1",
+        plan: "PRO",
+        meta: { remaining: 1000 },
+        rate_limit: 100,
+        roles: ["user", "pro"],
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    } as Response)
+
+    const result = await client.getCurrentUser()
+    expect(result.success).toBe(true)
+    expect(result.data.id).toBe("u_1")
+    expect(result.data.plan).toBe("PRO")
+    expect(result.data.rate_limit).toBe(100)
+    expect(result.data.roles).toEqual(["user", "pro"])
+  })
+
+  it("accepts envelope without version/created_at", async () => {
+    const body = {
+      success: true,
+      error: null,
+      data: {
+        id: "u_2",
+        full_name: "Community User",
+        email: "c@example.com",
+        owner_id: "o_2",
+        plan: "COMMUNITY",
+        meta: { remaining: 0 },
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    } as Response)
+
+    const result = await client.getCurrentUser()
+    expect(result.data.plan).toBe("COMMUNITY")
+    expect(result.version).toBeUndefined()
+    expect(result.created_at).toBeUndefined()
+  })
+})

--- a/tests/datatable.extras.test.ts
+++ b/tests/datatable.extras.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import { DataTable, createNetworkDate } from "../src"
+import type { INetworkTimeSeries } from "../src/types"
+
+const fixture: INetworkTimeSeries[] = [
+  {
+    network_code: "NEM",
+    metric: "energy",
+    unit: "MWh",
+    interval: "1d",
+    start: "2024-01-01T00:00:00",
+    end: "2024-01-03T00:00:00",
+    groupings: ["network_region"],
+    results: [
+      {
+        name: "nsw1",
+        date_start: "2024-01-01T00:00:00",
+        date_end: "2024-01-03T00:00:00",
+        columns: { network_region: "NSW1" },
+        data: [
+          ["2024-01-01T00:00:00", 100],
+          ["2024-01-02T00:00:00", 200],
+        ],
+      },
+      {
+        name: "vic1",
+        date_start: "2024-01-01T00:00:00",
+        date_end: "2024-01-03T00:00:00",
+        columns: { network_region: "VIC1" },
+        data: [
+          ["2024-01-01T00:00:00", 150],
+          ["2024-01-02T00:00:00", 250],
+        ],
+      },
+    ],
+    network_timezone_offset: "+10:00",
+  },
+  {
+    network_code: "NEM",
+    metric: "power",
+    unit: "MW",
+    interval: "1d",
+    start: "2024-01-01T00:00:00",
+    end: "2024-01-03T00:00:00",
+    groupings: ["network_region"],
+    results: [
+      {
+        name: "nsw1_p",
+        date_start: "2024-01-01T00:00:00",
+        date_end: "2024-01-03T00:00:00",
+        columns: { network_region: "NSW1" },
+        data: [
+          ["2024-01-01T00:00:00", 10],
+          ["2024-01-02T00:00:00", 20],
+        ],
+      },
+    ],
+    network_timezone_offset: "+10:00",
+  },
+]
+
+describe("DataTable.fromNetworkTimeSeries", () => {
+  it("populates rows, metrics, and groupings", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    expect(table.getGroupings()).toEqual(["network_region"])
+    expect(table.getMetrics().get("energy")).toBe("MWh")
+    expect(table.getMetrics().get("power")).toBe("MW")
+    expect(table.getRows().length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe("DataTable.getLatestTimestamp", () => {
+  it("returns the max interval timestamp", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    const expected = createNetworkDate("2024-01-02T00:00:00").getTime()
+    expect(table.getLatestTimestamp()).toBe(expected)
+  })
+
+  it("caches the result", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    const first = table.getLatestTimestamp()
+    const second = table.getLatestTimestamp()
+    expect(first).toBe(second)
+  })
+})
+
+describe("DataTable.select", () => {
+  it("keeps only requested columns and prunes metrics map", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    const projected = table.select(["network_region", "energy"])
+    expect(projected.getMetrics().has("energy")).toBe(true)
+    expect(projected.getMetrics().has("power")).toBe(false)
+    expect(projected.getGroupings()).toEqual(["network_region"])
+    const row = projected.getRows()[0]
+    expect("energy" in row).toBe(true)
+    expect("power" in row).toBe(false)
+  })
+})

--- a/tests/datatable.extras.test.ts
+++ b/tests/datatable.extras.test.ts
@@ -66,7 +66,7 @@ describe("DataTable.fromNetworkTimeSeries", () => {
     expect(table.getGroupings()).toEqual(["network_region"])
     expect(table.getMetrics().get("energy")).toBe("MWh")
     expect(table.getMetrics().get("power")).toBe("MW")
-    expect(table.getRows().length).toBeGreaterThanOrEqual(3)
+    expect(table.getRows()).toHaveLength(4)
   })
 })
 


### PR DESCRIPTION
## Summary

Two changes:

1. **fix(datatable)**: `DataTable.fromNetworkTimeSeries` crashed on empty
   `data` array because `data[0].groupings` threw. Affects pollution /
   facility queries returning no rows. Caught while writing the pollution
   empty-response test.

2. **test**: 16 new unit tests filling gaps in the existing suite:
   - `client.metrics.test.ts` — `getAvailableMetrics` happy + 404 + 403 + 500
   - `client.user.test.ts` — `getCurrentUser` full + minimal envelope (no
     version/created_at, COMMUNITY plan, roles, rate_limit)
   - `client.pollution.test.ts` — populated + empty + 404
   - `datatable.extras.test.ts` — `fromNetworkTimeSeries`, `getLatestTimestamp`
     cache, `select` projection
   - `client.tz_warning.test.ts` — Z, +HH:MM, and naive dateStart/dateEnd
     serialization

## Stack

Stacked on #14.

## Test plan

- [x] 64/64 tests pass (was 48)