### PR TITLE
fix(client): throw OpenElectricityError on 403 instead of bare Error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -175,7 +175,11 @@ export class OpenElectricityClient {
         status: response.status,
         statusText: response.statusText,
       })
-      throw new Error("Permission denied. Check API key or your access level")
+      throw new OpenElectricityError(
+        "Permission denied. Check API key or your access level",
+        undefined,
+        response.status,
+      )
     }
 
     // Try to parse JSON response, handle cases where response is not valid JSON

--- a/tests/client.metrics.test.ts
+++ b/tests/client.metrics.test.ts
@@ -56,7 +56,7 @@ describe("getAvailableMetrics", () => {
     )
   })
 
-  it("throws permission error on 403", async () => {
+  it("throws OpenElectricityError with statusCode 403 on permission denied", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 403,
@@ -64,9 +64,14 @@ describe("getAvailableMetrics", () => {
       json: () => Promise.resolve({}),
     } as Response)
 
-    await expect(client.getAvailableMetrics()).rejects.toThrow(
-      /Permission denied/,
-    )
+    try {
+      await client.getAvailableMetrics()
+      throw new Error("expected throw")
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenElectricityError)
+      expect((err as OpenElectricityError).statusCode).toBe(403)
+      expect((err as Error).message).toMatch(/Permission denied/)
+    }
   })
 
   it("throws OpenElectricityError on 500 with non-JSON body", async () => {

--- a/tests/facilities.test.ts
+++ b/tests/facilities.test.ts
@@ -366,10 +366,11 @@ describe("Facilities", () => {
       await client.getFacilities()
       fail("Expected error to be thrown")
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof OpenElectricityError) {
         expect(error.message).toBe("Permission denied. Check API key or your access level")
+        expect(error.statusCode).toBe(403)
       } else {
-        fail("Expected error to be an instance of Error")
+        fail("Expected error to be an instance of OpenElectricityError")
       }
     }
   })


### PR DESCRIPTION
Codex e2e review of v0.9.0 flagged this (R-001).

The 403 branch in \`request()\` short-circuited the typed-error path and threw a plain \`Error\`, so callers couldn't inspect \`statusCode\` or \`details\` the way they can for other API failures. That defeated the v0.9.0 promise that \`getAvailableMetrics\` and friends would surface typed errors uniformly.

This wraps the same human-readable message in \`OpenElectricityError\` with \`statusCode = 403\` and tightens the existing 403 tests to assert the new shape.

## Test plan

- [x] tsc --noEmit clean
- [x] 64/64 tests pass
- [x] facilities.test.ts and client.metrics.test.ts now assert \`instanceof OpenElectricityError\` and \`statusCode === 403\`