### PR TITLE
fix(datatable): correct groupBy cache and drop unsafe filter index path

### DIFF
--- a/src/datatable.ts
+++ b/src/datatable.ts
@@ -25,9 +25,8 @@ export interface IDescribeResult {
 
 interface IDataTableCache {
   sortedRows?: Map<string, IDataTableRow[]>
-  groupedRows?: Map<string, Map<string, IDataTableRow[]>>
+  groupedRows?: Map<string, IDataTableRow[]>
   latestTimestamp?: number
-  columnIndexes?: Map<string, Map<string | number | boolean, IDataTableRow[]>>
 }
 
 export class DataTable {
@@ -47,9 +46,7 @@ export class DataTable {
     this.metrics = metrics
     this.rowsMap = new Map()
 
-    // Create initial indexes
     this.createRowMap()
-    this.createColumnIndexes()
   }
 
   /**
@@ -115,31 +112,6 @@ export class DataTable {
     return parts.join("_")
   }
 
-  private createColumnIndexes(): void {
-    this.cache.columnIndexes = new Map()
-
-    // Create indexes for grouping columns
-    for (const column of this.groupings) {
-      const columnIndex = new Map<string | number | boolean, IDataTableRow[]>()
-
-      for (const row of this.rows) {
-        const value = row[column]
-        // Skip null values in index
-        if (value === null || value instanceof Date) continue
-
-        if (!columnIndex.has(value)) {
-          columnIndex.set(value, [])
-        }
-        const rows = columnIndex.get(value)
-        if (rows) {
-          rows.push(row)
-        }
-      }
-
-      this.cache.columnIndexes.set(column, columnIndex)
-    }
-  }
-
   /**
    * Get a row by its unique key
    * Used internally for efficient row lookups
@@ -196,41 +168,11 @@ export class DataTable {
    * Filter rows based on a condition
    */
   public filter(condition: (row: IDataTableRow) => boolean): DataTable {
-    // Check if we can use index for simple equality conditions
-    const indexedFilter = this.tryIndexFilter(condition)
-    if (indexedFilter) {
-      return indexedFilter
-    }
-
-    // Fall back to regular filter for complex conditions
-    const filteredRows = this.rows.filter(condition)
-    return new DataTable(filteredRows, this.groupings, this.metrics)
-  }
-
-  private tryIndexFilter(
-    condition: (row: IDataTableRow) => boolean,
-  ): DataTable | null {
-    // Try to find matching rows in our column indexes
-    for (const [column, columnIndex] of this.cache.columnIndexes || []) {
-      // Test the first row to see if this is a simple equality check on this column
-      if (this.rows.length === 0) return null
-      const testRow = { ...this.rows[0] }
-
-      // Try each possible value from the index
-      for (const [value, rows] of columnIndex) {
-        // Test if this is an equality check for this value
-        testRow[column] = value
-        const otherValues = { ...testRow }
-        otherValues[column] =
-          value === true ? false : value === false ? true : value === 0 ? 1 : 0
-
-        if (condition(testRow) && !condition(otherValues)) {
-          return new DataTable([...rows], this.groupings, this.metrics)
-        }
-      }
-    }
-
-    return null
+    return new DataTable(
+      this.rows.filter(condition),
+      this.groupings,
+      this.metrics,
+    )
   }
 
   /**
@@ -270,13 +212,9 @@ export class DataTable {
     aggregation: "sum" | "mean" = "sum",
   ): DataTable {
     const cacheKey = `${columns.join("_")}_${aggregation}`
-    const cachedGroups = this.cache.groupedRows?.get(cacheKey)
-    if (cachedGroups) {
-      return new DataTable(
-        Array.from(cachedGroups.values()).flat(),
-        columns,
-        this.metrics,
-      )
+    const cachedRows = this.cache.groupedRows?.get(cacheKey)
+    if (cachedRows) {
+      return new DataTable(cachedRows, columns, this.metrics)
     }
 
     const groups = new Map<string, IDataTableRow[]>()
@@ -354,11 +292,11 @@ export class DataTable {
       newRows.push(newRow)
     }
 
-    // Cache the results
+    // Cache the aggregated rows so repeated calls with the same args are stable
     if (!this.cache.groupedRows) {
       this.cache.groupedRows = new Map()
     }
-    this.cache.groupedRows.set(cacheKey, groups)
+    this.cache.groupedRows.set(cacheKey, newRows)
 
     return new DataTable(newRows, columns, this.metrics)
   }

--- a/tests/datatable.extras.test.ts
+++ b/tests/datatable.extras.test.ts
@@ -97,3 +97,35 @@ describe("DataTable.select", () => {
     expect("power" in row).toBe(false)
   })
 })
+
+describe("DataTable.groupBy", () => {
+  // Regression: cache previously stored raw groups, so the second call
+  // flattened the source rows instead of returning the aggregated ones.
+  it("returns the same aggregated rows on repeated calls", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    const first = table.groupBy(["network_region"], "sum")
+    const second = table.groupBy(["network_region"], "sum")
+    expect(second.getRows()).toEqual(first.getRows())
+    expect(second.getRows()).toHaveLength(2)
+
+    const nsw1 = second.getRows().find((r) => r.network_region === "NSW1")
+    expect(nsw1?.energy).toBe(300)
+    expect(nsw1?.power).toBe(30)
+  })
+})
+
+describe("DataTable.filter", () => {
+  // Regression: the index fast-path used to infer single-column equality
+  // from any predicate and could return rows that violated additional
+  // clauses. Filter must always behave like Array.filter.
+  it("respects multi-column predicates", () => {
+    const table = DataTable.fromNetworkTimeSeries(fixture)
+    const filtered = table.filter(
+      (row) => row.network_region === "NSW1" && (row.energy as number) > 150,
+    )
+    expect(filtered.getRows()).toHaveLength(1)
+    const row = filtered.getRows()[0]
+    expect(row.network_region).toBe("NSW1")
+    expect(row.energy).toBe(200)
+  })
+})


### PR DESCRIPTION
Codex e2e review of v0.9.0 flagged two pre-existing DataTable bugs (R-003, R-004).

## R-003 — groupBy cache returns raw rows on second call

\`groupBy()\` cached the raw per-group source rows but returned the aggregated \`newRows\` on the first call. On a cache hit it called \`Array.from(cachedGroups.values()).flat()\`, which is the original ungrouped rows, not the aggregated output. A second call with the same \`columns\`/\`aggregation\` returned unaggregated rows labelled with the grouped column names — i.e. silently different results.

Fix: cache the aggregated \`newRows\` directly; reshape the cache type to \`Map<string, IDataTableRow[]>\`.

## R-004 — filter index fast-path misfires on multi-column predicates

\`filter()\` had a \`tryIndexFilter\` "fast path" that inferred single-column equality by mutating one indexed column on a copy of \`rows[0]\` and checking which value flipped the predicate. For predicates that touched multiple columns, e.g. \`row.network_region === "NSW1" && row.energy > 150\`, this would match on the first indexed column and return every row with that column value — including rows that violated the other clauses.

Fix: drop \`tryIndexFilter\`, \`createColumnIndexes\`, and the \`columnIndexes\` cache (all only fed the unsafe path). \`filter()\` now always uses \`Array.filter\`.

## Regression tests

\`tests/datatable.extras.test.ts\`:
- \`groupBy\`: calling twice with same args returns identical aggregated rows.
- \`filter\`: multi-column predicate behaves like \`Array.filter\`.

## Test plan

- [x] tsc --noEmit clean
- [x] 66/66 tests pass (was 64)
- [x] new regression tests cover both code paths