### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.9.1
+
+Bug fixes surfaced by the v0.9.0 end-to-end review.
+
+### Fixed
+
+- `OpenElectricityClient.request()` now throws `OpenElectricityError` (with
+  `statusCode = 403`) on permission denied responses instead of a bare
+  `Error`. 403 handling now matches 404 (`NoDataFound`) and 500
+  (`OpenElectricityError`) for `getAvailableMetrics` and every other method.
+- `DataTable.groupBy()` cached the raw per-group source rows but returned
+  aggregated rows on the first call, so a second call with the same
+  arguments returned unaggregated data. The cache now stores the
+  aggregated `newRows`.
+- `DataTable.filter()` had an index "fast path" that inferred single-column
+  equality from arbitrary predicates and could return rows that violated
+  other clauses of a multi-column condition. The optimisation has been
+  removed; `filter()` always uses `Array.filter`.
+
 ## 0.9.0
 
 Parity sync with the Python SDK, CI matrix expansion, and tightened error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openelectricity",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "OpenElectricity API Typescript/Javascript client",
   "author": "OpenElectricity <enquiries@openelectricity.org.au>",
   "license": "MIT",


### PR DESCRIPTION
Point release covering the three bugs surfaced by the v0.9.0 end-to-end Codex review.

## Fixed (merged via #18, #19)

- **R-001**: \`request()\` 403 path now throws \`OpenElectricityError\` with \`statusCode = 403\` instead of a bare \`Error\`. All HTTP error responses now go through the typed error path.
- **R-003**: \`DataTable.groupBy()\` cached the raw groups but returned aggregated rows on the first call. Second calls with the same args returned unaggregated data. Cache now stores aggregated rows.
- **R-004**: \`DataTable.filter()\` had an unsafe index "fast path" that inferred predicate shape from probing and could return rows that violated multi-column conditions. Removed; \`filter()\` always uses \`Array.filter\`.

## Post-merge

- npm publish 0.9.1
- tag v0.9.1